### PR TITLE
Cleared up examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ Frameworkless is a simple example of how you can use just a few composer package
 If you're not just serving up JSON and raw responses, you might want to check out Twig. To use it, run: "composer require twig/twig". Then, inside of app.php, add:
 ````
 $container->add('Twig_Environment')
-    ->withArgument(new Twig_Loader_Filesystem(__DIR__ . '/../views/'))
+    ->withArgument(new Twig_Loader_Filesystem(__DIR__ . '/../views/'));
 ````
 Create a "views" directory inside of your project, and start adding *.html.twig files. To return a response with twig, inside of your controller, first add:
 ````
-    private $twig;
+private $twig;
 
-    function __construct(Twig_Environment $twig)
-    {
-        $this->twig = $twig;
-    }
+public function __construct(Twig_Environment $twig)
+{
+    $this->twig = $twig;
+}
 ````
 This will tell the container to inject a Twig_Environment instance to your controller. From there, inside a method add:
 ````
@@ -46,12 +46,11 @@ $container->add('\Spot\Locator')
 From here you can add models to any directory under src/, which will be autoloaded by composer. For example ( ``src/Models/Posts.php``): 
 
 ```php
-
 namespace Frameworkless\Models;
 
 class Posts extends \Spot\Entity
 {
-	protected static $table = 'posts';
+    protected static $table = 'posts';
 }
 
 ```
@@ -59,17 +58,18 @@ class Posts extends \Spot\Entity
 And finally from your controller:
 
 ```php
-    private $spot;
+private $spot;
 
-    function __construct(\Spot\Locator $spot)
-    {
-        $this->spot = $spot;
-    }
+public function __construct(\Spot\Locator $spot)
+{
+    $this->spot = $spot;
+}
 
-    public function get(){
-        $posts = $this->spot->mapper('Frameworkless\Models\Posts')->all() 
-        return new Response('Here are your posts' . print_r($posts, true));
-    }
+public function get()
+{
+    $posts = $this->spot->mapper('Frameworkless\Models\Posts')->all();
+    return new Response('Here are your posts' . print_r($posts, true));
+}
 ```
 
 ## Contributing


### PR DESCRIPTION
Removed preceding whitespace to improve readability.
Added ; and public visibility for __constructor's (because, well, PSR-2)
